### PR TITLE
GitHub Pages deploy, Dependabot, and README badge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  # Keep GitHub Actions up to date
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # Keep uv-managed Python dependencies up to date
+  - package-ecosystem: uv
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    # Only bump direct dependencies defined in pyproject
+    allow:
+      - dependency-type: direct

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,9 +3,6 @@ name: Deploy MkDocs to Pages
 on:
   push:
     branches: [ "main" ]
-  # Temporary: enable on PRs to test builds before merging
-  pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,54 @@
+name: Deploy MkDocs to Pages
+
+on:
+  push:
+    branches: [ "main" ]
+  # Temporary: enable on PRs to test builds before merging
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # needed for git revision date plugin
+
+      - name: Set up uv (Python + resolver)
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Build MkDocs site
+        run: uv run mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # mkdocs-example
 
 Simple MkDocs site with Material theme, dark mode, multilingual docs (English/Japanese), Mermaid diagrams, and Git-based "Last updated".
- 
-<a href="https://mkdocs-docs-template.pages.dev/" target="_blank" rel="noopener noreferrer" style="display:inline-block;padding:10px 16px;background:#0ea5e9;color:#fff;border-radius:6px;text-decoration:none;font-weight:600;">
-  Try it out →
-</a>
+
+[![Try it out →](https://img.shields.io/badge/-Try%20it%20out%20%E2%86%92-0ea5e9?style=for-the-badge&labelColor=0ea5e9)](https://mkdocs-docs-template.pages.dev/)
 
 ## Prerequisites
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ theme:
 
 # Define top-level tabs (per-language content is resolved by i18n)
 nav:
+  - Home: index.md
   - Developer Docs:
     - Overview: developer-docs/index.md
     - TypeScript Quickstart: developer-docs/typescript.md
@@ -34,7 +35,6 @@ plugins:
   - search
   - mermaid2
   - i18n:
-      default_language: en
       docs_structure: folder
       reconfigure_material: true
       languages:
@@ -50,6 +50,7 @@ plugins:
             User Docs: ユーザー向けドキュメント
             Overview: 概要
             TypeScript Quickstart: TypeScript クイックスタート
+            Home: ホーム
   - git-revision-date-localized:
       type: timeago
       enable_creation_date: true
@@ -61,4 +62,8 @@ markdown_extensions:
       line_spans: __span
       pygments_lang_class: true
   - pymdownx.inlinehilite
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:mermaid2.fence_mermaid


### PR DESCRIPTION
Summary

- Automates MkDocs build and deploy to GitHub Pages on main.
- Adds Dependabot for Actions and Python deps.
- Replaces inline-styled link in README with a Shields.io button.
